### PR TITLE
Ignore synthetic methods

### DIFF
--- a/src/main/kotlin/Annotations.kt
+++ b/src/main/kotlin/Annotations.kt
@@ -350,20 +350,6 @@ fun Field.isPrivate() = Modifier.isPrivate(modifiers)
 fun Field.isProtected() = Modifier.isProtected(modifiers)
 fun Field.isPackagePrivate() = !isPublic() && !isPrivate() && !isProtected()
 
-fun Any.asArray(): Array<*> {
-    return when (this) {
-        is ByteArray -> this.toTypedArray()
-        is ShortArray -> this.toTypedArray()
-        is IntArray -> this.toTypedArray()
-        is LongArray -> this.toTypedArray()
-        is FloatArray -> this.toTypedArray()
-        is DoubleArray -> this.toTypedArray()
-        is CharArray -> this.toTypedArray()
-        is BooleanArray -> this.toTypedArray()
-        else -> this as Array<*>
-    }
-}
-
 fun Executable.isJenisol() = setOf(
     RandomType::class.java,
     RandomParameters::class.java,

--- a/src/main/kotlin/Solution.kt
+++ b/src/main/kotlin/Solution.kt
@@ -42,7 +42,7 @@ class Solution(val solution: Class<*>) {
         (solution.declaredMethods.toSet() + solution.declaredConstructors.toSet())
             .filterNotNull()
             .filter {
-                !it.isPrivate() && !it.isJenisol() && !(it is Method && it.isBridge)
+                !it.isPrivate() && !it.isJenisol() && !it.isSynthetic && !(it is Method && it.isBridge)
             }.toSet().also {
                 checkDesign(it.isNotEmpty() || allFields.isNotEmpty()) { "Found no methods or fields to test" }
             }

--- a/src/main/kotlin/Submission.kt
+++ b/src/main/kotlin/Submission.kt
@@ -131,7 +131,7 @@ class Submission(val solution: Solution, val submission: Class<*>) {
     init {
         if (submission != solution.solution) {
             (submission.declaredMethods.toSet() + submission.declaredConstructors.toSet()).filter {
-                !it.isPrivate() && !(it is Method && it.isBridge)
+                !it.isPrivate() && !it.isSynthetic && !(it is Method && it.isBridge)
             }.forEach { executable ->
                 if (executable !in submissionExecutables.values) {
                     if (submission.isKotlin()) {

--- a/src/main/kotlin/generators/Parameters.kt
+++ b/src/main/kotlin/generators/Parameters.kt
@@ -12,7 +12,6 @@ import edu.illinois.cs.cs125.jenisol.core.Settings
 import edu.illinois.cs.cs125.jenisol.core.SimpleType
 import edu.illinois.cs.cs125.jenisol.core.Solution
 import edu.illinois.cs.cs125.jenisol.core.TestRunner
-import edu.illinois.cs.cs125.jenisol.core.asArray
 import edu.illinois.cs.cs125.jenisol.core.deepCopy
 import edu.illinois.cs.cs125.jenisol.core.fixedParametersMatchAll
 import edu.illinois.cs.cs125.jenisol.core.getRandomParametersMethodName
@@ -215,7 +214,7 @@ class GeneratorFactory(private val executables: Set<Executable>, val solution: S
                             "@$simpleName annotation for type ${klass.name} that is not used by the solution"
                         }
                         @Suppress("UNCHECKED_CAST")
-                        simpleArray[klass] = field.get(null).asArray().toSet().also { simpleCases ->
+                        simpleArray[klass] = field.get(null).boxArray().toSet().also { simpleCases ->
                             check(simpleCases.none { it == null }) { "@$simpleName values should not include null" }
                         } as Set<Any>
                     }
@@ -225,7 +224,7 @@ class GeneratorFactory(private val executables: Set<Executable>, val solution: S
                         check(klass in neededTypes || klass in arrayNeededTypes) {
                             "@$edgeName annotation for type ${klass.name} that is not used by the solution"
                         }
-                        edgeArray[klass] = field.get(null).asArray().toSet()
+                        edgeArray[klass] = field.get(null).boxArray().toSet()
                     }
                 }
             }
@@ -285,7 +284,7 @@ class GeneratorFactory(private val executables: Set<Executable>, val solution: S
                 }?.also { field ->
                     SimpleType.validate(field).also { klass ->
                         @Suppress("UNCHECKED_CAST")
-                        simpleArray[klass] = field.get(null).asArray().toSet().also { simpleCases ->
+                        simpleArray[klass] = field.get(null).boxArray().toSet().also { simpleCases ->
                             check(simpleCases.none { it == null }) { "@SimpleType arrays should not include null" }
                         } as Set<Any>
                     }
@@ -309,7 +308,7 @@ class GeneratorFactory(private val executables: Set<Executable>, val solution: S
                     it.firstOrNull()
                 }?.also { field ->
                     EdgeType.validate(field).also { klass ->
-                        edgeArray[klass] = field.get(null).asArray().toSet()
+                        edgeArray[klass] = field.get(null).boxArray().toSet()
                     }
                 }
                 klass.declaredMethods.filter { it.isEdgeType() }.let {

--- a/src/main/kotlin/generators/Type.kt
+++ b/src/main/kotlin/generators/Type.kt
@@ -689,19 +689,6 @@ fun <T> Class<T>.wrap(): Class<*> = when {
     else -> this
 }
 
-@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN", "RemoveRedundantQualifierName")
-fun Any.box(): Any = when {
-    this == Byte::class.java -> this as java.lang.Byte
-    this == Short::class.java -> this as java.lang.Short
-    this == Int::class.java -> this as java.lang.Integer
-    this == Long::class.java -> this as java.lang.Long
-    this == Float::class.java -> this as java.lang.Float
-    this == Double::class.java -> this as java.lang.Double
-    this == Char::class.java -> this as java.lang.Character
-    this == Boolean::class.java -> this as java.lang.Boolean
-    else -> this
-}
-
 @Suppress("ComplexMethod")
 fun Class<*>.boxType(): Class<*> = when {
     this == Byte::class.java -> java.lang.Byte::class.java
@@ -716,14 +703,14 @@ fun Class<*>.boxType(): Class<*> = when {
 }
 
 fun Any.boxArray(): kotlin.Array<*> = when (this) {
-    is ByteArray -> this.map { it.box() }.toTypedArray()
-    is ShortArray -> this.map { it.box() }.toTypedArray()
-    is IntArray -> this.map { it.box() }.toTypedArray()
-    is LongArray -> this.map { it.box() }.toTypedArray()
-    is FloatArray -> this.map { it.box() }.toTypedArray()
-    is DoubleArray -> this.map { it.box() }.toTypedArray()
-    is CharArray -> this.map { it.box() }.toTypedArray()
-    is BooleanArray -> this.map { it.box() }.toTypedArray()
+    is ByteArray -> this.toTypedArray()
+    is ShortArray -> this.toTypedArray()
+    is IntArray -> this.toTypedArray()
+    is LongArray -> this.toTypedArray()
+    is FloatArray -> this.toTypedArray()
+    is DoubleArray -> this.toTypedArray()
+    is CharArray -> this.toTypedArray()
+    is BooleanArray -> this.toTypedArray()
     is kotlin.Array<*> -> this
     else -> error("Value is not an array: ${this::class.java}")
 }

--- a/src/test/java/edu/illinois/cs/cs125/jenisol/core/TestJavaExamples.kt
+++ b/src/test/java/edu/illinois/cs/cs125/jenisol/core/TestJavaExamples.kt
@@ -325,6 +325,9 @@ class TestJavaExamples : StringSpec(
         examples.java.noreceiver.kotlinprivatemethod.Correct::class.java.also {
             "${it.testName()}" { it.test() }
         }
+        examples.java.noreceiver.kotlinsynthetic.Correct::class.java.also {
+            "${it.testName()}" { it.test() }
+        }
         examples.java.receiver.timeouttest.Correct::class.java.also {
             "${it.testName()}" {
                 val runnable = object : Runnable {

--- a/src/test/java/examples/java/noreceiver/kotlinsynthetic/Correct.java
+++ b/src/test/java/examples/java/noreceiver/kotlinsynthetic/Correct.java
@@ -1,0 +1,7 @@
+package examples.java.noreceiver.kotlinsynthetic;
+
+public class Correct {
+  public static int addOne(int value) {
+    return value + 1;
+  }
+}

--- a/src/test/java/examples/java/noreceiver/kotlinsynthetic/Correct0.kt
+++ b/src/test/java/examples/java/noreceiver/kotlinsynthetic/Correct0.kt
@@ -1,0 +1,10 @@
+package examples.java.noreceiver.kotlinsynthetic
+
+fun addOne(value: Int): Int {
+    val transform = ::plus1 // Private method reference creates public synthetic accessor
+    return transform(value)
+}
+
+private fun plus1(x: Int): Int {
+    return x + 1
+}

--- a/src/test/java/examples/java/noreceiver/kotlinsynthetic/Incorrect0.kt
+++ b/src/test/java/examples/java/noreceiver/kotlinsynthetic/Incorrect0.kt
@@ -1,0 +1,15 @@
+package examples.java.noreceiver.kotlinsynthetic
+
+class Incorrect0 {
+    companion object {
+        @JvmStatic // Can't have two loose addOne Kotlin functions in the same package
+        fun addOne(value: Int): Int {
+            val transform = ::plus2
+            return transform(value)
+        }
+
+        private fun plus2(x: Int): Int {
+            return x + 2
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/cs125-illinois/jenisol/commit/9a63990e23251113efa40aa68409cac28082af2b ignores synthetic methods such as those that enable inner classes to access private members of their enclosing class. This allows Kotlin method references to be used.

https://github.com/cs125-illinois/jenisol/commit/ca7e783cbb1226275aef4f808b393d8b36e9a807 simplifies array boxing and makes e.g. `int[]` box to `Integer[]` instead of `Object[]`. If boxing primitive arrays to `Object[]` is desired, `.map { it.box() }` could instead be replaced with `.map<Any> { it }`.